### PR TITLE
GuzzleException stub

### DIFF
--- a/stubs/Exception/GuzzleException.php
+++ b/stubs/Exception/GuzzleException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Exception;
 
 /**

--- a/stubs/Exception/GuzzleException.php
+++ b/stubs/Exception/GuzzleException.php
@@ -1,0 +1,13 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * @method string getMessage()
+ * @method \Throwable|null getPrevious()
+ * @method mixed getCode()
+ * @method string getFile()
+ * @method int getLine()
+ * @method array getTrace()
+ * @method string getTraceAsString()
+ */
+interface GuzzleException extends \Throwable {}

--- a/stubs/Handler/MockHandler.php
+++ b/stubs/Handler/MockHandler.php
@@ -1,9 +1,6 @@
 <?php
 
-declare(strict_types=1);
-
 namespace GuzzleHttp\Handler;
-
 
 class MockHandler
 {

--- a/stubs/Handler/MockHandler.php
+++ b/stubs/Handler/MockHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Handler;
+
+
+class MockHandler
+{
+    /**
+     * @psalm-variadic
+     */
+    public function append() {}
+}


### PR DESCRIPTION
Another one for you. I was experiencing issues with the `GuzzleException` interface as it doesn't extend `Throwable`. This means Psalm throws up errors when attempting to catch a Guzzle exception.