### PR TITLE
Add Psalm 4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "vimeo/psalm": "^3"
+        "vimeo/psalm": "^3 || ^4"
     },
     "extra": {
         "psalm" : {


### PR DESCRIPTION
None of the BC breaks in Psalm 4 affect this plugin, so this is just a `composer.json` change.