### PR TITLE
Adapt array shapes for psalm5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "vimeo/psalm": "^3 || ^4 || ^5"
+        "vimeo/psalm": "^5"
     },
     "extra": {
         "psalm" : {

--- a/stubs/Client.php
+++ b/stubs/Client.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\UriInterface;
 /**
  * @psalm-type handler_fn callable(RequestInterface, array):PromiseInterface<ResponseInterface>
  *
- * @psalm-type guzzle_client_config=array{handler?:handler_fn,base_uri?:string|UriInterface|null}
+ * @psalm-type guzzle_client_config=array{handler?:handler_fn,base_uri?:string|UriInterface|null,...}
  */
 class Client implements ClientInterface
 {

--- a/stubs/Client.php
+++ b/stubs/Client.php
@@ -8,9 +8,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
- * @psalm-type handler_fn callable(RequestInterface, array):PromiseInterface<ResponseInterface>
+ * @psalm-type handler_fn = callable(RequestInterface, array):PromiseInterface<ResponseInterface>
  *
- * @psalm-type guzzle_client_config=array{handler?:handler_fn,base_uri?:string|UriInterface|null,...}
+ * @psalm-type guzzle_client_config = array{handler?: handler_fn, base_uri?: string|UriInterface|null, ...}
  */
 class Client implements ClientInterface
 {

--- a/stubs/Handler/CurlMultiHandler.php
+++ b/stubs/Handler/CurlMultiHandler.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
 class CurlMultiHandler
 {
     /**
-     * @param array{handle_factory?:CurlFactoryInterface,select_timeout?:int|float,options?:array} $options
+     * @param array{handle_factory?: CurlFactoryInterface, select_timeout?: int|float, options?: array} $options
      */
     public function __construct(array $options = []) {}
 

--- a/stubs/Handler/CurlMultiHandler.php
+++ b/stubs/Handler/CurlMultiHandler.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
 class CurlMultiHandler
 {
     /**
-     * @param array{handle_factory?:CurlFactoryInterface,select_timeout?:int|float} $options
+     * @param array{handle_factory?:CurlFactoryInterface,select_timeout?:int|float,options?:array} $options
      */
     public function __construct(array $options = []) {}
 

--- a/stubs/HandlerStack.php
+++ b/stubs/HandlerStack.php
@@ -6,8 +6,8 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * @psalm-type handler_fn callable(RequestInterface, array):PromiseInterface<ResponseInterface>
- * @psalm-type middleware_fn callable(handler_fn):handler_fn
+ * @psalm-type handler_fn = callable(RequestInterface, array):PromiseInterface<ResponseInterface>
+ * @psalm-type middleware_fn = callable(handler_fn):handler_fn
  */
 class HandlerStack
 {

--- a/stubs/Middleware.php
+++ b/stubs/Middleware.php
@@ -8,8 +8,8 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
 /**
- * @psalm-type handler_fn callable(RequestInterface, array):PromiseInterface<ResponseInterface>
- * @psalm-type middleware_fn callable(handler_fn):handler_fn
+ * @psalm-type handler_fn = callable(RequestInterface, array):PromiseInterface<ResponseInterface>
+ * @psalm-type middleware_fn = callable(handler_fn):handler_fn
  */
 final class Middleware
 {

--- a/stubs/Pool.php
+++ b/stubs/Pool.php
@@ -10,14 +10,14 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * @template-implements PromisorInterface<void>
  *
- * @psalm-type pool_config array{
- *  concurrency?:int,
- *  pool_size?:int,
- *  options?:array,
- *  fulfilled?:callable(mixed, mixed, PromiseInterface):void,
- *  rejected?:callable(mixed, mixed, PromiseInterface):void
+ * @psalm-type pool_config = array{
+ *  concurrency?: int,
+ *  pool_size?: int,
+ *  options?: array,
+ *  fulfilled?: callable(mixed, mixed, PromiseInterface):void,
+ *  rejected?: callable(mixed, mixed, PromiseInterface):void
  * }
- * @psalm-type requests_iterable iterable<RequestInterface>|iterable<callable(array):PromiseInterface<ResponseInterface>>
+ * @psalm-type requests_iterable = iterable<RequestInterface>|iterable<callable(array):PromiseInterface<ResponseInterface>>
  */
 class Pool implements PromisorInterface
 {

--- a/stubs/Promise/EachPromise.php
+++ b/stubs/Promise/EachPromise.php
@@ -12,9 +12,9 @@ class EachPromise implements PromisorInterface
      *
      * @param iterable<TKey, PromiseInterface<TValue>> $iterable
      * @param array{
-     *  concurrency?:int,
-     *  fulfilled?:callable(TValue, TKey, PromiseInterface):void,
-     *  rejected?:callable(mixed, TKey, PromiseInterface):void
+     *  concurrency?: int,
+     *  fulfilled?: callable(TValue, TKey, PromiseInterface):void,
+     *  rejected?: callable(mixed, TKey, PromiseInterface):void
      * } $config
      */
     public function __construct($iterable, array $config = []) {}

--- a/stubs/Promise/PromiseInterface.php
+++ b/stubs/Promise/PromiseInterface.php
@@ -5,7 +5,7 @@ namespace GuzzleHttp\Promise;
 /**
  * @template T of mixed
  *
- * @psalm-type rejected_fn callable(mixed):(PromiseInterface|mixed)
+ * @psalm-type rejected_fn = callable(mixed):(PromiseInterface|mixed)
  *
  * @see https://github.com/vimeo/psalm/issues/1283
  */

--- a/stubs/Promise/functions.php
+++ b/stubs/Promise/functions.php
@@ -46,7 +46,7 @@ function iter_for($value) {}
  *
  * @param PromiseInterface<T> $promise
  *
- * @return array{state:string, value?:T|\Exception|mixed, reason?:string}
+ * @return array{state: string, value?: T|\Exception|mixed, reason?: string}
  */
 function inspect(PromiseInterface $promise) {}
 

--- a/stubs/Promise/functions.php
+++ b/stubs/Promise/functions.php
@@ -46,7 +46,7 @@ function iter_for($value) {}
  *
  * @param PromiseInterface<T> $promise
  *
- * @return array{state:string, value:T|\Exception|mixed}
+ * @return array{state:string, value?:T|\Exception|mixed, reason?:string}
  */
 function inspect(PromiseInterface $promise) {}
 
@@ -55,7 +55,7 @@ function inspect(PromiseInterface $promise) {}
  *
  * @param iterable<PromiseInterface<T>> $promises
  *
- * @return array<array{state:string, value:T|\Exception|mixed}>
+ * @return array<array{state:string, value?:T|\Exception|mixed, reason?:string}>
  */
 function inspect_all($promises) {}
 
@@ -108,7 +108,7 @@ function any($promises) {}
  *
  * @param iterable<TKey, PromiseInterface<TValue>> $promises
  *
- * @return PromiseInterface<array<TKey, array{state:string, value:TValue|\Exception|mixed}>>
+ * @return PromiseInterface<array<TKey, array{state:string, value?:TValue|\Exception|mixed, reason?:string}>>
  */
 function settle($promises)
 {


### PR DESCRIPTION
Array shapes in psalm 5 do not allow extra keys anymore, unless explicitly specified in the shape definition using `...`.
See 'sealed vs unsealed array shapes' in https://psalm.dev/articles/psalm-5

This means that psalm 5 will throw errors for example when a Guzzle client is constructed with additional request options.

This PR adapts the current array shape definitions in the stubs to work with psalm 5.

This breaks backwards compat with earlier psalm versions which do not support the '...' extension in array shapes.